### PR TITLE
Add option to convert SQL_VARCHAR to SQL_LONGVARCHAR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ option(EDBA_S_BACKEND_SHARED "Use backends as shared libraries for static versio
 option(EDBA_ENABLE "Enable shared versions of core libraries" ON)
 option(EDBA_S_ENABLE "Enable static version of core libraries" ON)
 
+option(EDBA_CONVERT_VARCHAR_TO_LONGVARCHAR "Enable conversion of SQL_VARCHAR to SQL_LONGVARCHAR when target type param size is 0" OFF)
+
+if (EDBA_CONVERT_VARCHAR_TO_LONGVARCHAR)
+  add_definitions(-DCONVERT_SQL_VARCHAR_TO_SQL_LONGVARCHAR_WHEN_PARAM_SIZE_EQUAL_ZERO)
+endif()
+
 # Use own helpers
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,6 @@ option(EDBA_S_BACKEND_SHARED "Use backends as shared libraries for static versio
 option(EDBA_ENABLE "Enable shared versions of core libraries" ON)
 option(EDBA_S_ENABLE "Enable static version of core libraries" ON)
 
-option(EDBA_CONVERT_VARCHAR_TO_LONGVARCHAR "Enable conversion of SQL_VARCHAR to SQL_LONGVARCHAR when target type param size is 0" OFF)
-
-if (EDBA_CONVERT_VARCHAR_TO_LONGVARCHAR)
-  add_definitions(-DCONVERT_SQL_VARCHAR_TO_SQL_LONGVARCHAR_WHEN_PARAM_SIZE_EQUAL_ZERO)
-endif()
-
 # Use own helpers
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 

--- a/backends/odbc/odbc_backend.cpp
+++ b/backends/odbc/odbc_backend.cpp
@@ -838,10 +838,8 @@ private:
                 params_desc_.clear();
                 return;
             }
-            #ifdef CONVERT_SQL_VARCHAR_TO_SQL_LONGVARCHAR_WHEN_PARAM_SIZE_EQUAL_ZERO
             if (d.data_type_ == SQL_VARCHAR && d.param_size_ == 0)
                 d.data_type_ = SQL_LONGVARCHAR;
-            #endif
         }
     }
 

--- a/backends/odbc/odbc_backend.cpp
+++ b/backends/odbc/odbc_backend.cpp
@@ -838,6 +838,10 @@ private:
                 params_desc_.clear();
                 return;
             }
+            #ifdef CONVERT_SQL_VARCHAR_TO_SQL_LONGVARCHAR_WHEN_PARAM_SIZE_EQUAL_ZERO
+            if (d.data_type_ == SQL_VARCHAR && d.param_size_ == 0)
+                d.data_type_ = SQL_LONGVARCHAR;
+            #endif
         }
     }
 


### PR DESCRIPTION
Use case: ODBC with SQL server native client,
when server column type is varchar(max) and data is over 8k
